### PR TITLE
Add inheritance metadata to the datatype struct descriptor

### DIFF
--- a/docs/idl/NC-Framework.webidl
+++ b/docs/idl/NC-Framework.webidl
@@ -317,8 +317,7 @@ $macro(ModelDatatypes)
 	interface NcDatatypeDescriptorStruct: NcDatatypeDescriptor {
 		//type will be Struct
 		sequence<NcFieldDescriptor>	content;	// one item descriptor per field of the struct
-		NcName	inheretedType;	// names of the inherited type
-		sequence<NcName>	derivedTypes;	// names of all the derived types
+		NcName?	parentType;	// name of the parent type if any
 	};
 
 	interface NcDatatypeDescriptorEnum: NcDatatypeDescriptor {

--- a/docs/idl/NC-Framework.webidl
+++ b/docs/idl/NC-Framework.webidl
@@ -317,6 +317,8 @@ $macro(ModelDatatypes)
 	interface NcDatatypeDescriptorStruct: NcDatatypeDescriptor {
 		//type will be Struct
 		sequence<NcFieldDescriptor>	content;	// one item descriptor per field of the struct
+		NcName	inheretedType;	// names of the inherited type
+		sequence<NcName>	derivedTypes;	// names of all the derived types
 	};
 
 	interface NcDatatypeDescriptorEnum: NcDatatypeDescriptor {


### PR DESCRIPTION
Add inheritance metadata to the datatype struct descriptor:
- inherited type name
- sequence of derived types

These are only valid if the struct data type involves inheritance concepts.