### PR TITLE
Improvements and clarifications

### DIFF
--- a/docs/Framework.md
+++ b/docs/Framework.md
@@ -286,9 +286,17 @@ NcClassManager is the class manager control class.
 
 ## Datatypes
 
-Control class models are documented using WebIDL interfaces.
+Datatype models are documented using WebIDL fragments.
 
 The `[primitive]` extended attribute identifies primitive datatypes.
+
+The `typedef` attribute identifies typedef datatypes if they do not also have the `[primitive]` extended attribute.
+
+Struct datatypes are documented using WebIDL interfaces.
+
+The `enum` attribute identifies enum datatypes.
+
+[NcDatatypeType](#ncdatatypetype) contains all the possible types of datatype.
 
 ### Primitives
 
@@ -653,7 +661,7 @@ interface NcMethodResultId: NcMethodResult {
 ```typescript
 // Length method result
 interface NcMethodResultLength: NcMethodResult {
-    attribute NcUint32    value; // Length result value
+    attribute NcUint32?    value; // Length result value. Can be null if the underlying sequence is null
 };
 ```
 

--- a/docs/Framework.md
+++ b/docs/Framework.md
@@ -661,7 +661,7 @@ interface NcMethodResultId: NcMethodResult {
 ```typescript
 // Length method result
 interface NcMethodResultLength: NcMethodResult {
-    attribute NcUint32?    value; // Length result value. Can be null if the underlying sequence is null
+    attribute NcUint32?    value; // Sequence length result value. MUST be null if the sequence is null
 };
 ```
 

--- a/docs/NcObject.md
+++ b/docs/NcObject.md
@@ -31,7 +31,7 @@ Lack of the `readonly` token does not guarantee the property can be changed usin
 
 ## PropertyChanged event
 
-NcObject offers a PropertyChanged event `[element("1e1")]` which MUST trigger anytime a property on the object is changed.
+NcObject defines a PropertyChanged event `[element("1e1")]` which MUST trigger anytime a property on the object is changed.
 The event data is of type [NcPropertyChangedEventData](Framework.md#ncpropertychangedeventdata).
 
 Events can only be consumed as notifications when subscribed to. Subscriptions and their implementation are protocol-specific. For more details refer to [IS-12 NMOS Control Protocol](https://specs.amwa.tv/is-12/branches/v1.0-dev/docs/Protocol_messaging.html).

--- a/models/datatypes/NcMethodResultLength.json
+++ b/models/datatypes/NcMethodResultLength.json
@@ -4,7 +4,7 @@
   "type": 2,
   "fields": [
     {
-      "description": "Length result value. Can be null if the underlying sequence is null",
+      "description": "Sequence length result value. MUST be null if the sequence is null",
       "name": "value",
       "typeName": "NcUint32",
       "isNullable": true,

--- a/models/datatypes/NcMethodResultLength.json
+++ b/models/datatypes/NcMethodResultLength.json
@@ -4,10 +4,10 @@
   "type": 2,
   "fields": [
     {
-      "description": "Length result value",
+      "description": "Length result value. Can be null if the underlying sequence is null",
       "name": "value",
       "typeName": "NcUint32",
-      "isNullable": false,
+      "isNullable": true,
       "isSequence": false,
       "constraints": null
     }


### PR DESCRIPTION
- Update NcObject.md to clarify the "PropertyChanged event" section.
- Make the value in NcMethodResultLength nullable
- Add clarifications around how datatypes are documented using different WebIDL fragments